### PR TITLE
Include tinyxml2 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tinyxml2"]
+	path = tinyxml2
+	url = https://github.com/leethomason/tinyxml2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # mkpsxiso build script (rewritten)
 # (C) 2021 spicyjpeg
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.20)
 
 project(
 	mkpsxiso
@@ -45,11 +45,6 @@ endfunction()
 _add_target(mkpsxiso src)
 #_add_target(mkisoxml mkisoxml/src)
 
-install(
-	TARGETS mkpsxiso
-	#RUNTIME_DEPENDENCIES
-	#PRE_EXCLUDE_REGEXES ".*"
-	#PRE_INCLUDE_REGEXES "tinyxml2"
-)
+install(TARGETS mkpsxiso)
 
 include(InstallRequiredSystemLibraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 # (C) 2021 spicyjpeg
 
 cmake_minimum_required(VERSION 3.21)
-#include(FindPkgConfig)
 
 project(
 	mkpsxiso
@@ -18,8 +17,8 @@ set(CMAKE_CXX_STANDARD         11)
 
 ## External dependencies
 
-if(NOT EXISTS tinyxml2/tinyxml2.cpp)
-	message(FATAL_ERROR "The tinyxml2 directory is empty. Run 'git submodule update --init' to populate it.")
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/tinyxml2/tinyxml2.cpp)
+	message(FATAL_ERROR "The tinyxml2 directory is empty. Run 'git submodule update --init --recursive' to populate it.")
 endif()
 
 # Build tinyxml2. I didn't bother with tinyxml2's actual CMake integration
@@ -52,3 +51,5 @@ install(
 	#PRE_EXCLUDE_REGEXES ".*"
 	#PRE_INCLUDE_REGEXES "tinyxml2"
 )
+
+include(InstallRequiredSystemLibraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,31 +7,29 @@ cmake_minimum_required(VERSION 3.21)
 project(
 	mkpsxiso
 	LANGUAGES    C CXX
-	VERSION      1.26
+	VERSION      1.27
 	DESCRIPTION  "PlayStation ISO image maker"
 	HOMEPAGE_URL "https://github.com/Lameguy64/mkpsxiso"
 )
 
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set(CMAKE_C_STANDARD           11)
+set(CMAKE_CXX_STANDARD         11)
+
 ## External dependencies
 
-# Let CMake attempt to find tinyxml2 on its own first. This avoids invoking
-# pkg-config where it might not be installed, and allows usage of package
-# managers like vcpkg. The path to tinyxml2 can also be specified manually by
-# passing -Dtinyxml2_ROOT.
-find_package(tinyxml2 CONFIG)
-
-if(NOT tinyxml2_FOUND)
-	find_package(PkgConfig REQUIRED)
-	pkg_search_module(_tinyxml2 REQUIRED IMPORTED_TARGET tinyxml2)
-
-	add_library(tinyxml2::tinyxml2 ALIAS PkgConfig::_tinyxml2)
+if(NOT EXISTS tinyxml2/tinyxml2.cpp)
+	message(FATAL_ERROR "The tinyxml2 directory is empty. Run 'git submodule update --init' to populate it.")
 endif()
 
-## Executables
+# Build tinyxml2. I didn't bother with tinyxml2's actual CMake integration
+# because it's far easier do do this. It is a single-file library after all.
+add_library               (tinyxml2 STATIC tinyxml2/tinyxml2.cpp)
+target_include_directories(tinyxml2 PUBLIC tinyxml2)
 
-# This is required in order to properly link against tinyxml2 under MSVC.
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-set(CMAKE_CXX_STANDARD         11)
+#add_subdirectory(tinyxml2)
+
+## Executables
 
 function(_add_target name source_dir)
 	file(
@@ -42,16 +40,15 @@ function(_add_target name source_dir)
 
 	add_executable            (${name} ${_sources})
 	target_compile_definitions(${name} PUBLIC VERSION="${PROJECT_VERSION}")
-	target_link_libraries     (${name} tinyxml2::tinyxml2)
+	target_link_libraries     (${name} tinyxml2)
 endfunction()
 
 _add_target(mkpsxiso src)
 #_add_target(mkisoxml mkisoxml/src)
 
-# Ensure the tinyxml2 DLL (if any) is installed alongside mkpsxiso.
 install(
 	TARGETS mkpsxiso
-	RUNTIME_DEPENDENCIES
-	PRE_EXCLUDE_REGEXES ".*"
-	PRE_INCLUDE_REGEXES "tinyxml2"
+	#RUNTIME_DEPENDENCIES
+	#PRE_EXCLUDE_REGEXES ".*"
+	#PRE_INCLUDE_REGEXES "tinyxml2"
 )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+
 # MKPSXISO
+
 MKPSXISO is basically a modern clone of BUILDCD used for building CD images of PlayStation games in the official development tools. The problem with BUILDCD however is, apart from licensing issues, its an old 16-bit DOS program which will not work natively under 64-bit versions of Windows without a DOS emulator which not only makes automated build scripts that produce ISO images messy in homebrew development but it also slows ISO creation speed considerably. BUILDCD also only produces CD images in a special image format supported by early CD burners and must be converted to an ISO format with a separate tool making the already slow ISO creation process even slower.
 
 While other ISO creation tools such as MKISOFS may work as an alternative most do not let you control the order of the files stored in the ISO image which is essential for optimizing file order to speed up access times and all do not support mixed-mode type files for CD streaming such as XA audio and MDEC video streams. MKPSXISO is made specifically to replace BUILDCD to aid in PlayStation homebrew development on modern systems as well as modification/hacking of existing PlayStation titles. MKPSXISO can also be used as a regular ISO creation tool that complies with the older ISO9660 standard with no Joliet extensions.
@@ -8,6 +10,7 @@ MKPSXISO more or less replicates most of the functionality of BUILDCD but better
 Another notable difference of MKPSXISO is that it injects the Sony license data correctly into the disc image which eliminates the need of having to use a separate program for properly licensing the ISO image. However, the license data is not included so one must have a copy of the official PlayStation Programmer's Tool SDK or the PsyQ SDK (both of which can be found in www.psxdev.net) for the license files to be able to take advantage of this feature. This is to avoid possible legal problems when including Sony's license data into open source programs.
 
 ## Features
+
 * Uses XML for scripting ISO projects.
 * Outputs ISO images directly to iso or bin+cue image format.
 * Injects license data into ISO image correctly.
@@ -17,9 +20,11 @@ Another notable difference of MKPSXISO is that it injects the Sony license data 
 * Can output log of all files packed with details such as LBA, size and timecode offset.
 
 ## Binary Download
+
 The latest Win32 binaries is now a release download in this repository.
 
 Older versions (probably going to be removed soon, there's no benefit to using these versions anyway):
+
 * [mkpsxiso-1.20.zip](http://lameguy64.github.io/mkpsxiso/mkpsxiso-1.20.zip)
 * [mkpsxiso-1.19.zip](http://lameguy64.github.io/mkpsxiso/mkpsxiso-1.19.zip)
 * [mkpsxiso-1.18.zip](http://lameguy64.github.io/mkpsxiso/mkpsxiso-1.18.zip)
@@ -34,13 +39,13 @@ Older versions (probably going to be removed soon, there's no benefit to using t
 
 1. Set up CMake and a compiler toolchain. Install the `cmake` and `build-essential` packages provided by your Linux distro, or one of the following kits on Windows:
    * MSVC (do not install CMake through the Visual Studio installer, download it from [here](https://cmake.org/download) instead)
-   * MSys64 (use the "MinGW 64-bit" shell) with the following packages: `git`, `mingw-w64-x86_64-make`, `mingw-w64-x86_64-cmake`, `mingw-w64-x86_64-gcc`
+   * MSys2 (use the "MinGW 64-bit" shell) with the following packages: `git`, `mingw-w64-x86_64-make`, `mingw-w64-x86_64-cmake`, `mingw-w64-x86_64-g++`
    * Cygwin64 with the following packages: `git`, `make`, `cmake`, `gcc`
 
-2. Clone/download the repo, then run the following command from the mkpsxiso directory to ensure `tinyxml2` is also downloaded:
+2. Clone/download the repo, then run the following command from the mkpsxiso directory to ensure `tinyxml2` is also downloaded and updated:
 
    ```bash
-   git submodule update --init
+   git submodule update --init --recursive --remote
    ```
 
 3. Run the following commands:
@@ -58,6 +63,7 @@ The default installation path is `C:\Program Files\mkpsxiso\bin` on Windows or `
 ## Issues
 
 The only known major issue that hasn't (or cannot) be resolved is that if you create a disc image with the following directory structure:
+
 ```xml
 <dir name="dira">
     <dir name="subdir1a">
@@ -95,6 +101,7 @@ This can be avoided by minimizing identically named directories but its best to 
 **Version 1.27**
 * Fixed stringop overflow bug when temporarily clearing sector address bytes.
 * Path is now stripped for the .bin file specification of cue sheets.
+* Added tinyxml2 as a submodule, so manual installation is no longer needed and built binaries will always be statically linked.
 
 **Version 1.25 (12/30/2020)**
 * Replaced xa and str modes with "mixed" mode (see example.xml for details). xa and str modes are now just aliases to the new "mixed" mode, for backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -33,19 +33,25 @@ Older versions (probably going to be removed soon, there's no benefit to using t
 ## Compiling
 
 1. Set up CMake and a compiler toolchain. Install the `cmake` and `build-essential` packages provided by your Linux distro, or one of the following kits on Windows:
-   * MSVC with vcpkg (do not install CMake through the Visual Studio installer, download it from [here](https://cmake.org/download) instead)
-   * MSys64 with the following packages: `make`, `cmake`, `mingw-w64-x86_64-gcc`, `mingw-w64-x86_64-tinyxml2`
-   * Cygwin64 with the following packages: `make`, `cmake`, `gcc`, `tinyxml2`
-2. Install `tinyxml2` using vcpkg, your distro's package manager or build it manually from [its repo](https://github.com/leethomason/tinyxml2).
-3. Run the following commands from the mkpsxiso directory:
+   * MSVC (do not install CMake through the Visual Studio installer, download it from [here](https://cmake.org/download) instead)
+   * MSys64 (use the "MinGW 64-bit" shell) with the following packages: `git`, `mingw-w64-x86_64-make`, `mingw-w64-x86_64-cmake`, `mingw-w64-x86_64-gcc`
+   * Cygwin64 with the following packages: `git`, `make`, `cmake`, `gcc`
 
-```bash
-cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Release
-cmake --build build/
-cmake --install build/
-```
+2. Clone/download the repo, then run the following command from the mkpsxiso directory to ensure `tinyxml2` is also downloaded:
 
-**NOTE**: Add `sudo` to the install command if necessary. If you are using vcpkg, add `-DCMAKE_TOOLCHAIN_FILE` to the first command as explained [here](https://github.com/microsoft/vcpkg#using-vcpkg-with-cmake).
+   ```bash
+   git submodule update --init
+   ```
+
+3. Run the following commands:
+
+   ```bash
+   cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release
+   cmake --build ./build
+   cmake --install ./build
+   ```
+
+   Add `sudo` to the install command if necessary.
 
 The default installation path is `C:\Program Files\mkpsxiso\bin` on Windows or `/usr/local/bin` on Linux. You can change it to any directory by passing `--install-prefix` to the first command.
 


### PR DESCRIPTION
I got rid of all the `tinyxml2` auto-finding logic and just included it within the repo as a submodule. This solves all issues with `tinyxml2` being linked dynamically in some cases (and `install(RUNTIME_DEPENDENCIES)` sometimes not finding and installing the DLL properly), and removes the need for the library to be installed ahead-of-time via vcpkg or a package manager. It should also be possible to roll the minimum required CMake version back to 3.20, since `install(RUNTIME_DEPENDENCIES)` was the only thing requiring CMake 3.21.

I cleaned up and updated build instructions in README.md as well.