### PR TITLE
mkpsxiso: CDDA packing - use miniaudio for pcm packing

### DIFF
--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -123,7 +123,7 @@ int Main(int argc, char* argv[])
 	{
 		printf( "MKPSXISO " VERSION " - PlayStation ISO Image Maker\n" );
 		printf( "2017-2018 Meido-Tek Productions (Lameguy64)\n" );
-		printf( "2021 Silent and Chromaryu\n\n" );
+		printf( "2021 Silent, Chromaryu, and G4Vi\n\n" );
 	}
 
 	if ( argc == 1 )
@@ -1305,8 +1305,7 @@ int PackFileAsCDDA(cd::IsoWriter* writer, const std::filesystem::path& audioFile
 			tryorder[3] = DAF_MP3;
 		}
 	}
-	VirtualWav vw;
-	unique_file pcmFp;
+	VirtualWavEx vw;
 	const int num_tries = std::size(tryorder);
 	int i;
 	for(i = 0; i < num_tries; i++)
@@ -1333,11 +1332,7 @@ int PackFileAsCDDA(cd::IsoWriter* writer, const std::filesystem::path& audioFile
 		else if(tryorder[i] == DAF_PCM)
 		{
 			printf("\n    WARN: Guessing it's just signed 16 bit stereo @ 44100 kHz pcm audio\n");
-			if(MA_SUCCESS == ma_decoder_init_path_pcm(audioFile, &decoderConfig, &decoder, &vw))
-			{
-				pcmFp = unique_file(vw.file);
-				break;
-			}
+			if(MA_SUCCESS == ma_decoder_init_path_pcm(audioFile, &decoderConfig, &decoder, &vw)) break;
 		}
 	}
 	if(i == num_tries)

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -17,6 +17,7 @@
 #define MA_NO_DEVICE_IO
 #define MINIAUDIO_IMPLEMENTATION
 #include "miniaudio.h"
+#include "miniaudio_pcm.h"
 
 
 namespace global
@@ -1304,8 +1305,8 @@ int PackFileAsCDDA(cd::IsoWriter* writer, const std::filesystem::path& audioFile
 			tryorder[3] = DAF_MP3;
 		}
 	}
+	VirtualWav vw;
 	unique_file pcmFp;
-
 	const int num_tries = std::size(tryorder);
 	int i;
 	for(i = 0; i < num_tries; i++)
@@ -1332,45 +1333,11 @@ int PackFileAsCDDA(cd::IsoWriter* writer, const std::filesystem::path& audioFile
 		else if(tryorder[i] == DAF_PCM)
 		{
 			printf("\n    WARN: Guessing it's just signed 16 bit stereo @ 44100 kHz pcm audio\n");
-			unique_file fp = OpenScopedFile(audioFile, "rb");
-	        if(fp)
-	        {
-				if(fseek(fp.get(), 0, SEEK_END) != 0)
-				{
-					printf("    ERROR: (PCM) fseek failed\n");
-					continue;
-				} 
-				pcmBytesLeft = ftell(fp.get());    
-				if(pcmBytesLeft < 0)
-				{
-					printf("    ERROR: (PCM) ftell failed\n");
-					continue;
-				}
-	        	if(pcmBytesLeft == 0)
-	        	{
-	        		printf("    ERROR: (PCM) byte count is 0\n");
-	        		continue;
-	        	}
-	        	// 2 channels of 16 bit samples
-	        	if((pcmBytesLeft % (2 * sizeof(int16_t))) != 0)
-	        	{
-	        		printf("    ERROR: (PCM) byte count indicates non-integer sample count\n");
-	        		continue;
-	        	}
-				if(fseek(fp.get(), 0, SEEK_SET) != 0)
-				{
-					printf("    ERROR: (PCM) fseek failed\n");
-					continue;
-				}
-
-				// Success, persist the opened file
-				pcmFp = std::move(fp);
+			if(MA_SUCCESS == ma_decoder_init_path_pcm(audioFile, &decoderConfig, &decoder, &vw))
+			{
+				pcmFp = unique_file(vw.file);
 				break;
-	        }
-	        else
-	        {
-	        	printf("    ERROR: (PCM) fopen failed\n");
-	        }
+			}
 		}
 	}
 	if(i == num_tries)
@@ -1378,27 +1345,6 @@ int PackFileAsCDDA(cd::IsoWriter* writer, const std::filesystem::path& audioFile
 		// no more formats to try, return false
 	    printf("    ERROR: No valid format found\n");
 	    return false;	
-	}
-
-    // if it's stereo s16lepcm just copy the data sector by sector
-	if(pcmFp)
-	{
-		unsigned char buff[CD_SECTOR_SIZE];
-		for(;;) {
-			memset(buff, 0x00, CD_SECTOR_SIZE);
-			size_t nowRead = fread( buff, 1, CD_SECTOR_SIZE, pcmFp.get() );
-			writer->WriteBytesRaw( buff, CD_SECTOR_SIZE);
-			if(pcmBytesLeft == nowRead)
-			{
-				return true;
-			}
-			else if(nowRead != CD_SECTOR_SIZE)
-			{
-				printf("\n    ERROR: fread didn't read CD_SECTOR_SIZE\n");
-				return false;
-			}
-			pcmBytesLeft -= nowRead;
-		};	
 	}
 
     //  note if there's some data converting going on

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -117,9 +117,9 @@ static ma_result stdio_file_size(FILE *file, uint64_t *pSizeInBytes)
     MA_ASSERT(file  != NULL);
 
 #if defined(_MSC_VER)
-    fd = _fileno((FILE*)file);
+    fd = _fileno(file);
 #else
-    fd =  fileno((FILE*)file);
+    fd =  fileno(file);
 #endif
 
     if (fstat(fd, &info) != 0) {

--- a/src/mkpsxiso/miniaudio_pcm.h
+++ b/src/mkpsxiso/miniaudio_pcm.h
@@ -1,0 +1,205 @@
+#pragma once
+#include "platform.h"
+
+typedef struct {
+    uint8_t header[44];
+    uint64_t pos;   // actual file position
+    uint64_t vpos;  // virtual file position
+    uint64_t vsize; // virtual file size
+    FILE *file;
+} VirtualWav;
+
+MA_API ma_result ma_decoder_init_path_pcm(const std::filesystem::path& pFilePath, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWav *pUserData);
+
+#if defined(MINIAUDIO_IMPLEMENTATION) || defined(MA_IMPLEMENTATION)
+
+static size_t virtual_wav_read(ma_decoder *pDecoder, void *pBufferOut, size_t bytesToRead)
+{
+    VirtualWav *vw = (VirtualWav *)pDecoder->pUserData;
+    size_t bytesRead = 0;
+    if(vw->vpos < 44)
+    {
+        const size_t headerread = drwav_min(bytesToRead, 44-vw->vpos);
+        memcpy(pBufferOut, &vw->header[vw->vpos], headerread);
+        vw->vpos += headerread;
+        bytesRead += headerread;
+        bytesToRead -= headerread;
+        pBufferOut = ((uint8_t*)pBufferOut) + headerread;        
+    }
+    if(bytesToRead > 0)
+    {
+        const size_t actualread = fread(pBufferOut, 1, bytesToRead, vw->file);
+        bytesRead += actualread;
+        vw->vpos += actualread;
+        vw->pos += actualread;
+    }
+    return bytesRead;
+}
+
+static ma_bool32 virtual_wav_seek(ma_decoder *pDecoder, ma_int64 byteOffset, ma_seek_origin origin)
+{
+    int whence;
+    int result;
+    VirtualWav *vw = (VirtualWav *)pDecoder->pUserData;
+
+    if (origin == ma_seek_origin_start) {
+        if(byteOffset < 0) return MA_FALSE;
+        if(byteOffset > vw->vsize) return MA_FALSE;
+        vw->vpos = byteOffset;
+        byteOffset = drwav_max(byteOffset - 44, 0);
+        vw->pos = byteOffset;
+        whence = SEEK_SET;
+    } else if (origin == ma_seek_origin_end) {
+        if(byteOffset > 0) return MA_FALSE;
+        if((byteOffset + vw->vsize) < 0) return MA_FALSE;
+        vw->vpos = vw->vsize + byteOffset;
+        byteOffset = drwav_max(byteOffset, -(vw->vsize - 44));
+        vw->pos = (vw->vsize - 44) + byteOffset;
+        whence = SEEK_END;
+    } else {
+        if((byteOffset+vw->vpos) > vw->vsize) return MA_FALSE;
+        if((byteOffset+vw->vpos) < 0) return MA_FALSE;
+        vw->vpos += byteOffset;
+        uint64_t abspos = vw->pos + byteOffset;
+        if(abspos < 0)
+        {
+            byteOffset = -vw->pos;
+        }
+        else if(abspos > (vw->vsize-44))
+        {
+            byteOffset = (vw->vsize-44) - vw->pos;
+        }
+        vw->pos += byteOffset;
+        whence = SEEK_CUR;
+    }
+
+#if defined(_WIN32)
+    #if defined(_MSC_VER) && _MSC_VER > 1200
+        result = _fseeki64(vw->file, byteOffset, whence);
+    #else
+        /* No _fseeki64() so restrict to 31 bits. */
+        if (origin > 0x7FFFFFFF) {
+            return MA_FALSE;
+        }
+
+        result = fseek(vw->file, (int)byteOffset, whence);
+    #endif
+#else
+    result = fseek(vw->file, (long int)byteOffset, whence);
+#endif
+    if (result != 0) {
+        return MA_FALSE;
+    }
+
+    return MA_TRUE;
+}
+
+static long stdio_file_size(FILE *file)
+{
+    if(fseek(file, 0, SEEK_END) != 0)
+	{
+		printf("    ERROR: (PCM) fseek failed\n");
+		return -1;
+	} 
+	const long pcmSize = ftell(file);    
+	if(pcmSize < 0)
+	{
+		printf("    ERROR: (PCM) ftell failed\n");
+        return -1;
+    }
+    if(fseek(file, 0, SEEK_SET) != 0)
+	{
+		printf("    ERROR: (PCM) fseek failed\n");
+		return -1;
+	}
+    return pcmSize;
+}
+
+// feed to pcm file to miniaudio as a wav file
+MA_API ma_result ma_decoder_init_path_pcm(const std::filesystem::path& pFilePath, ma_decoder_config* pConfig, ma_decoder* pDecoder, VirtualWav *pUserData)
+{
+    FILE *file = OpenFile(pFilePath, "rb");
+    if(file == nullptr)
+    {
+        return !MA_SUCCESS;
+    }
+
+    const long pcmSize = stdio_file_size(file);
+    if(pcmSize == -1)
+    {
+        fclose(file);
+        return !MA_SUCCESS;
+    }
+    else if(pcmSize == 0)
+	{
+		printf("    ERROR: (PCM) byte count is 0\n");
+		fclose(file);
+        return !MA_SUCCESS;
+	}
+	// 2 channels of 16 bit samples
+	else if((pcmSize % (2 * sizeof(int16_t))) != 0)
+	{
+		printf("    ERROR: (PCM) byte count indicates non-integer sample count\n");
+		fclose(file);
+        return !MA_SUCCESS;
+	}
+				
+
+    pUserData->pos = 0;
+    pUserData->vpos = 0;
+    pUserData->vsize = pcmSize+44;
+
+
+    memcpy(&pUserData->header[0], "RIFF", 4);
+    const unsigned chunksize = (44 - 8) + pcmSize;
+    pUserData->header[4] = chunksize;
+    pUserData->header[5] = chunksize >> 8;
+    pUserData->header[6] = chunksize >> 16;
+    pUserData->header[7] = chunksize >> 24;
+    memcpy(&pUserData->header[8], "WAVE", 4);
+    memcpy(&pUserData->header[12], "fmt ", 4);
+    const unsigned subchunk1size = 16;
+    pUserData->header[16] = subchunk1size;
+    pUserData->header[17] = subchunk1size >> 8;
+    pUserData->header[18] = subchunk1size >> 16;
+    pUserData->header[19] = subchunk1size >> 24;
+    pUserData->header[20] = 1;
+    pUserData->header[21] = 0;
+    const unsigned numchannels = 2;
+    pUserData->header[22] = numchannels;
+    pUserData->header[23] = 0;
+    const unsigned samplerate = 44100;
+    pUserData->header[24] = (uint8_t)samplerate;
+    pUserData->header[25] = samplerate >> 8;
+    pUserData->header[26] = samplerate >> 16;
+    pUserData->header[27] = samplerate >> 24;
+    const unsigned bitspersample = 16;
+    const unsigned byteRate = (samplerate * numchannels * (bitspersample/8));
+    pUserData->header[28] = byteRate;
+    pUserData->header[29] = byteRate >> 8;
+    pUserData->header[30] = byteRate >> 16;
+    pUserData->header[31] = byteRate >> 24;
+    const uint16_t blockalign = numchannels * (bitspersample/8);;
+    pUserData->header[32] = blockalign;
+    pUserData->header[33] = blockalign >> 8;
+    pUserData->header[34] = bitspersample;
+    pUserData->header[35] = bitspersample >> 8;
+    memcpy(&pUserData->header[36], "data", 4);
+    pUserData->header[40] = pcmSize;
+    pUserData->header[41] = pcmSize >> 8;
+    pUserData->header[42] = pcmSize >> 16;
+    pUserData->header[43] = pcmSize >> 24;
+
+    pUserData->file = file;
+
+    pConfig->encodingFormat = ma_encoding_format_wav;
+    if(ma_decoder_init(&virtual_wav_read, &virtual_wav_seek, pUserData, pConfig, pDecoder) != MA_SUCCESS)
+    {
+        fclose(file);
+        return !MA_SUCCESS;
+    }
+
+    return MA_SUCCESS;    
+}
+
+#endif


### PR DESCRIPTION
Added some wrappers for miniaudio to decode pcm using it's wav decoder. Writing a pcm backend for miniaudio was attempted, but it makes the sanity checks on pcm audio such as verifying the file is a length of pcm frame units (2 channels of 16 bit audio) impossible, so the much simpler alternative of feeding the data to the `dr_wav` decoder was used. 

This makes pcm packing not a special case. This will help with [ Unifying DA tracks with regular CDDA tracks #7 ](https://github.com/CookiePLMonster/mkpsxiso/issues/7) by allowing miniaudio apis to be used for all audio formats.