### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Update repo submodules
       run: |
         cd mkpsxiso
-        git submodule update --init --recursive --remote
+        git submodule update --init --recursive
 
     - name: Build and package mkpsxiso
       run: |
@@ -61,7 +61,7 @@ jobs:
     - name: Update repo submodules
       run: |
         cd mkpsxiso
-        git submodule update --init --recursive --remote
+        git submodule update --init --recursive
 
     - name: Build and package mkpsxiso
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,18 @@ add_executable(mkpsxiso
 )
 target_include_directories(mkpsxiso PUBLIC "miniaudio")
 target_link_libraries(mkpsxiso tinyxml2 iso_shared)
+if(MINGW)
+	target_link_libraries(mkpsxiso "-municode")
+endif()
 
 add_executable(dumpsxiso
 	${dumpsxiso_dir}/cdreader.cpp
 	${dumpsxiso_dir}/main.cpp
 )
 target_link_libraries(dumpsxiso tinyxml2 iso_shared)
+if(MINGW)
+	target_link_libraries(dumpsxiso "-municode")
+endif()
 
 ## Installation
 


### PR DESCRIPTION
Remove `--remote` from ` git submodule update`, so the CI builds with dependencies pinned at the versions used by the repo. This fixes all CI builds failing as miniaudio had a breaking API change.

Add `-municode` linking flag to MINGW builds, so wmain is used there too (Fixes the windows CI trying to use WinMain and failing). 