### PR TITLE
Memory mapped based ISO writing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(
 )
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-set(CMAKE_C_STANDARD           17)
+set(CMAKE_C_STANDARD           11)
 set(CMAKE_CXX_STANDARD         17)
 
 # Useful paths
@@ -46,6 +46,8 @@ add_library(iso_shared OBJECT
 target_include_directories(iso_shared PUBLIC ${shared_dir})
 target_compile_definitions(iso_shared PUBLIC VERSION="${PROJECT_VERSION}")
 
+find_package(Threads REQUIRED)
+
 ## Executables
 
 add_executable(mkpsxiso
@@ -55,7 +57,7 @@ add_executable(mkpsxiso
 	${mkpsxiso_dir}/main.cpp
 )
 target_include_directories(mkpsxiso PUBLIC "miniaudio")
-target_link_libraries(mkpsxiso tinyxml2 iso_shared)
+target_link_libraries(mkpsxiso tinyxml2 iso_shared Threads::Threads)
 if(MINGW)
 	target_link_libraries(mkpsxiso "-municode")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories(tinyxml2 PUBLIC tinyxml2)
 # Populate shared files
 add_library(iso_shared OBJECT
 	${shared_dir}/common.cpp
+	${shared_dir}/mmappedfile.cpp
 	${shared_dir}/platform.cpp
 )
 target_include_directories(iso_shared PUBLIC ${shared_dir})

--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -281,7 +281,7 @@ void ExtractFiles(cd::IsoReader& reader, const std::list<cd::IsoDirEntries::Entr
 
 				size_t sectorsToRead = GetSizeInSectors(entry.entry.entrySize.lsb);
 
-				size_t cddaSize = 2352 * sectorsToRead;
+				size_t cddaSize = CD_SECTOR_SIZE * sectorsToRead;
 				size_t bytesLeft = cddaSize;
 
 				cd::RIFF_HEADER riffHeader;
@@ -509,12 +509,6 @@ void WriteXMLByDirectories(const cd::IsoDirEntries* directory, tinyxml2::XMLElem
 	}
 }
 
-typedef struct {
-	unsigned lba;
-	unsigned size;
-	std::string source;
-} cdtrack;
-
 void ParseISO(cd::IsoReader& reader) {
 
     cd::ISO_DESCRIPTOR descriptor;
@@ -641,11 +635,11 @@ void ParseISO(cd::IsoReader& reader) {
 			for(auto& dafile : dafiles)
 			{
 				// add to make track element later
-				tracks.push_back({
+				tracks.emplace_back(
 					dafile.entry.entryOffs.lsb,
 					dafile.entry.entrySize.lsb,
 					(sourcePath / dafile.virtualPath / CleanIdentifier(dafile.identifier)).generic_u8string()
-				});
+				);
 
 				// add back in to the rest of the files
 				for(auto it = entries.begin(); it != entries.end(); it++)

--- a/src/mkpsxiso/cdwriter.cpp
+++ b/src/mkpsxiso/cdwriter.cpp
@@ -6,81 +6,87 @@
 #endif
 
 #include <string.h>
+#include <cassert>
 #include "common.h"
 #include "cdwriter.h"
 #include "edcecc.h"
 #include "platform.h"
 
+using namespace cd;
 
-cd::ISO_USHORT_PAIR cd::SetPair16(unsigned short val) {
+
+
+static const EDCECC EDC_ECC_GEN;
+
+ISO_USHORT_PAIR cd::SetPair16(unsigned short val) {
     return { val, SwapBytes16(val) };
 }
 
-cd::ISO_UINT_PAIR cd::SetPair32(unsigned int val) {
+ISO_UINT_PAIR cd::SetPair32(unsigned int val) {
 	return { val, SwapBytes32(val) };
 }
 
 
-cd::IsoWriter::IsoWriter() {
+IsoWriter::IsoWriter() {
 
-	cd::IsoWriter::filePtr			= nullptr;
-	cd::IsoWriter::sectorM2F1		= nullptr;
-	cd::IsoWriter::sectorM2F2		= nullptr;
-	cd::IsoWriter::currentByte		= 0;
-	cd::IsoWriter::currentSector	= 0;
-	cd::IsoWriter::bytesWritten		= 0;
-	cd::IsoWriter::lastSectorType	= 0;
+	IsoWriter::filePtr			= nullptr;
+	IsoWriter::sectorM2F1		= nullptr;
+	IsoWriter::sectorM2F2		= nullptr;
+	IsoWriter::currentByte		= 0;
+	IsoWriter::currentSector	= 0;
+	IsoWriter::bytesWritten		= 0;
+	IsoWriter::lastSectorType	= 0;
 
-	memset(cd::IsoWriter::sectorBuff, 0, CD_SECTOR_SIZE);
+	memset(IsoWriter::sectorBuff, 0, CD_SECTOR_SIZE);
 
 }
 
-cd::IsoWriter::~IsoWriter() {
+IsoWriter::~IsoWriter() {
 
 	Close();
 }
 
-void cd::IsoWriter::PrepSector(int edcEccMode) {
+void IsoWriter::PrepSector(int edcEccMode) {
 
-    memset(cd::IsoWriter::sectorM2F1->sync, 0xff, 12);
-    cd::IsoWriter::sectorM2F1->sync[0]	= 0x00;
-    cd::IsoWriter::sectorM2F1->sync[11]	= 0x00;
+    memset(IsoWriter::sectorM2F1->sync, 0xff, 12);
+    IsoWriter::sectorM2F1->sync[0]	= 0x00;
+    IsoWriter::sectorM2F1->sync[11]	= 0x00;
 
-	int taddr,addr = 150+cd::IsoWriter::currentSector;	// Sector addresses always start at LBA 150
+	int taddr,addr = 150+IsoWriter::currentSector;	// Sector addresses always start at LBA 150
 
 	taddr = addr%75;
-	cd::IsoWriter::sectorM2F1->addr[2] = (16*(taddr/10))+(taddr%10);
+	IsoWriter::sectorM2F1->addr[2] = (16*(taddr/10))+(taddr%10);
 
 	taddr = (addr/75)%60;
-	cd::IsoWriter::sectorM2F1->addr[1] = (16*(taddr/10))+(taddr%10);
+	IsoWriter::sectorM2F1->addr[1] = (16*(taddr/10))+(taddr%10);
 
 	taddr = (addr/75)/60;
-	cd::IsoWriter::sectorM2F1->addr[0] = (16*(taddr/10))+(taddr%10);
+	IsoWriter::sectorM2F1->addr[0] = (16*(taddr/10))+(taddr%10);
 
-	cd::IsoWriter::sectorM2F1->mode = 0x02;
+	IsoWriter::sectorM2F1->mode = 0x02;
 
-	if (edcEccMode == cd::IsoWriter::EdcEccForm1) {
+	/*if (edcEccMode == IsoWriter::EdcEccForm1) {
 
 		// Encode EDC data
-		edcEccGen.ComputeEdcBlock(cd::IsoWriter::sectorM2F1->subHead, 0x808, cd::IsoWriter::sectorM2F1->edc);
+		edcEccGen.ComputeEdcBlock(IsoWriter::sectorM2F1->subHead, 0x808, IsoWriter::sectorM2F1->edc);
 
 		// Encode ECC data
 
 		// Compute ECC P code
 		static const unsigned char zeroaddress[4] = { 0, 0, 0, 0 };
-		edcEccGen.ComputeEccBlock(zeroaddress, cd::IsoWriter::sectorBuff+0x10, 86, 24, 2, 86, cd::IsoWriter::sectorBuff+0x81C);
+		edcEccGen.ComputeEccBlock(zeroaddress, IsoWriter::sectorBuff+0x10, 86, 24, 2, 86, IsoWriter::sectorBuff+0x81C);
 		// Compute ECC Q code
-		edcEccGen.ComputeEccBlock(zeroaddress, cd::IsoWriter::sectorBuff+0x10, 52, 43, 86, 88, cd::IsoWriter::sectorBuff+0x8C8);
+		edcEccGen.ComputeEccBlock(zeroaddress, IsoWriter::sectorBuff+0x10, 52, 43, 86, 88, IsoWriter::sectorBuff+0x8C8);
 
-	} else if (edcEccMode == cd::IsoWriter::EdcEccForm2) {
+	} else if (edcEccMode == IsoWriter::EdcEccForm2) {
 
-		edcEccGen.ComputeEdcBlock(cd::IsoWriter::sectorM2F1->subHead, 0x91C, &cd::IsoWriter::sectorM2F2->data[2332]);
+		edcEccGen.ComputeEdcBlock(IsoWriter::sectorM2F1->subHead, 0x91C, &IsoWriter::sectorM2F2->data[2332]);
 
-	}
+	}*/
 
 }
 
-size_t cd::IsoWriter::WriteSectorToDisc()
+size_t IsoWriter::WriteSectorToDisc()
 {
 	const size_t bytesRead = fwrite(sectorBuff, CD_SECTOR_SIZE, 1, filePtr);
 	currentByte = 0;
@@ -88,79 +94,40 @@ size_t cd::IsoWriter::WriteSectorToDisc()
 	return bytesRead;
 }
 
-bool cd::IsoWriter::Create(const std::filesystem::path& fileName) {
+bool IsoWriter::Create(const std::filesystem::path& fileName, unsigned int sizeLBA)
+{
+	const uint64_t sizeBytes = static_cast<uint64_t>(sizeLBA) * CD_SECTOR_SIZE;
 
-	cd::IsoWriter::filePtr = OpenFile(fileName, "wb");
+	m_mmap = std::make_unique<MMappedFile>();
+	return m_mmap->Create(fileName, sizeBytes);
+}
 
-	if (cd::IsoWriter::filePtr == nullptr)
-		return(false);
+int IsoWriter::SeekToSector(int sector) {
 
-	cd::IsoWriter::currentByte		= 0;
-	cd::IsoWriter::currentSector	= 0;
+	assert(!"Dead code");
 
-	cd::IsoWriter::sectorM2F1		= (cd::SECTOR_M2F1*)cd::IsoWriter::sectorBuff;
-	cd::IsoWriter::sectorM2F2		= (cd::SECTOR_M2F2*)cd::IsoWriter::sectorBuff;
-
-	cd::IsoWriter::bytesWritten		= 0;
-
-	memset(cd::IsoWriter::sectorBuff, 0, CD_SECTOR_SIZE);
-
-	return(true);
+	return 0;
 
 }
 
-int cd::IsoWriter::SeekToSector(int sector) {
+int IsoWriter::SeekToEnd() {
 
-	if (cd::IsoWriter::currentByte) {
+	assert(!"Dead code");
 
-		cd::IsoWriter::PrepSector(cd::IsoWriter::lastSectorType);
-		WriteSectorToDisc();
-	}
-
-	fseek(cd::IsoWriter::filePtr, CD_SECTOR_SIZE*sector, SEEK_SET);
-
-	cd::IsoWriter::currentSector = sector;
-	cd::IsoWriter::currentByte = 0;
-
-	cd::IsoWriter::sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-    cd::IsoWriter::sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
-
-	return sector;
+	return 0;
 
 }
 
-int cd::IsoWriter::SeekToEnd() {
-
-	if (cd::IsoWriter::currentByte) {
-
-		cd::IsoWriter::PrepSector(cd::IsoWriter::lastSectorType);
-		WriteSectorToDisc();
-	}
-
-	fseek(cd::IsoWriter::filePtr, 0, SEEK_END);
-
-	int sector = ftell(cd::IsoWriter::filePtr)/CD_SECTOR_SIZE;
-
-	cd::IsoWriter::currentSector = sector;
-	cd::IsoWriter::currentByte = 0;
-
-	cd::IsoWriter::sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-    cd::IsoWriter::sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
-
-	return sector;
-
-}
-
-size_t cd::IsoWriter::WriteBytes(void* data, size_t bytes, int edcEccEncode) {
+size_t IsoWriter::WriteBytes(void* data, size_t bytes, int edcEccEncode) {
 
     size_t writeBytes = 0;
 
 	char*  	dataPtr = (char*)data;
     int		toWrite;
 
-	memcpy(cd::IsoWriter::sectorM2F1->subHead, cd::IsoWriter::subHeadBuff, 8);
+	memcpy(IsoWriter::sectorM2F1->subHead, IsoWriter::subHeadBuff, 8);
 
-	cd::IsoWriter::lastSectorType = edcEccEncode;
+	IsoWriter::lastSectorType = edcEccEncode;
 
     while(bytes > 0) {
 
@@ -169,29 +136,29 @@ size_t cd::IsoWriter::WriteBytes(void* data, size_t bytes, int edcEccEncode) {
 		else
 			toWrite = bytes;
 
-		memcpy(&cd::IsoWriter::sectorM2F1->data[cd::IsoWriter::currentByte], dataPtr, toWrite);
+		memcpy(&IsoWriter::sectorM2F1->data[IsoWriter::currentByte], dataPtr, toWrite);
 
-		cd::IsoWriter::currentByte += toWrite;
+		IsoWriter::currentByte += toWrite;
 
 		dataPtr += toWrite;
 		bytes -= toWrite;
 
-		if (cd::IsoWriter::currentByte >= 2048) {
+		if (IsoWriter::currentByte >= 2048) {
 
-			cd::IsoWriter::PrepSector(edcEccEncode);
+			IsoWriter::PrepSector(edcEccEncode);
 
             if (WriteSectorToDisc() == 0) {
 
-				cd::IsoWriter::currentByte = 0;
+				IsoWriter::currentByte = 0;
 				return(writeBytes);
 
             }
 
-            cd::IsoWriter::currentByte = 0;
-            cd::IsoWriter::currentSector++;
+            IsoWriter::currentByte = 0;
+            IsoWriter::currentSector++;
 
-            cd::IsoWriter::sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-			cd::IsoWriter::sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
+            IsoWriter::sectorM2F1 = (SECTOR_M2F1*)sectorBuff;
+			IsoWriter::sectorM2F2 = (SECTOR_M2F2*)sectorBuff;
 
 		}
 
@@ -203,14 +170,14 @@ size_t cd::IsoWriter::WriteBytes(void* data, size_t bytes, int edcEccEncode) {
 
 }
 
-size_t cd::IsoWriter::WriteBytesXA(void* data, size_t bytes, int edcEccEncode) {
+size_t IsoWriter::WriteBytesXA(void* data, size_t bytes, int edcEccEncode) {
 
     size_t writeBytes = 0;
 
 	char*  	dataPtr = (char*)data;
     int		toWrite;
 
-	cd::IsoWriter::lastSectorType = edcEccEncode;
+	IsoWriter::lastSectorType = edcEccEncode;
 
     while(bytes > 0) {
 
@@ -219,29 +186,29 @@ size_t cd::IsoWriter::WriteBytesXA(void* data, size_t bytes, int edcEccEncode) {
 		else
 			toWrite = bytes;
 
-		memcpy(&cd::IsoWriter::sectorM2F2->data[cd::IsoWriter::currentByte], dataPtr, toWrite);
+		memcpy(&IsoWriter::sectorM2F2->data[IsoWriter::currentByte], dataPtr, toWrite);
 
-		cd::IsoWriter::currentByte += toWrite;
+		IsoWriter::currentByte += toWrite;
 
 		dataPtr += toWrite;
 		bytes -= toWrite;
 
-		if (cd::IsoWriter::currentByte >= 2336) {
+		if (IsoWriter::currentByte >= 2336) {
 
-			cd::IsoWriter::PrepSector(edcEccEncode);
+			IsoWriter::PrepSector(edcEccEncode);
 
             if (WriteSectorToDisc() == 0) {
 
-				cd::IsoWriter::currentByte = 0;
+				IsoWriter::currentByte = 0;
 				return(writeBytes);
 
             }
 
-            cd::IsoWriter::currentByte = 0;
-            cd::IsoWriter::currentSector++;
+            IsoWriter::currentByte = 0;
+            IsoWriter::currentSector++;
 
-            cd::IsoWriter::sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-			cd::IsoWriter::sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
+            IsoWriter::sectorM2F1 = (SECTOR_M2F1*)sectorBuff;
+			IsoWriter::sectorM2F2 = (SECTOR_M2F2*)sectorBuff;
 
 		}
 
@@ -253,14 +220,14 @@ size_t cd::IsoWriter::WriteBytesXA(void* data, size_t bytes, int edcEccEncode) {
 
 }
 
-size_t cd::IsoWriter::WriteBytesRaw(const void* data, size_t bytes) {
+size_t IsoWriter::WriteBytesRaw(const void* data, size_t bytes) {
 
     size_t writeBytes = 0;
 
 	char*  	dataPtr = (char*)data;
     int		toWrite;
 
-	cd::IsoWriter::lastSectorType = EdcEccNone;
+	//IsoWriter::lastSectorType = EdcEccNone;
 
     while(bytes > 0) {
 
@@ -269,27 +236,27 @@ size_t cd::IsoWriter::WriteBytesRaw(const void* data, size_t bytes) {
 		else
 			toWrite = bytes;
 
-		memcpy(&cd::IsoWriter::sectorBuff[cd::IsoWriter::currentByte], dataPtr, toWrite);
+		memcpy(&IsoWriter::sectorBuff[IsoWriter::currentByte], dataPtr, toWrite);
 
-		cd::IsoWriter::currentByte += toWrite;
+		IsoWriter::currentByte += toWrite;
 
 		dataPtr += toWrite;
 		bytes -= toWrite;
 
-		if (cd::IsoWriter::currentByte >= 2352) {
+		if (IsoWriter::currentByte >= 2352) {
 
             if (WriteSectorToDisc() == 0) {
 
-				cd::IsoWriter::currentByte = 0;
+				IsoWriter::currentByte = 0;
 				return(writeBytes);
 
             }
 
-            cd::IsoWriter::currentByte = 0;
-            cd::IsoWriter::currentSector++;
+            IsoWriter::currentByte = 0;
+            IsoWriter::currentSector++;
 
-            cd::IsoWriter::sectorM2F1 = (cd::SECTOR_M2F1*)sectorBuff;
-			cd::IsoWriter::sectorM2F2 = (cd::SECTOR_M2F2*)sectorBuff;
+            IsoWriter::sectorM2F1 = (SECTOR_M2F1*)sectorBuff;
+			IsoWriter::sectorM2F2 = (SECTOR_M2F2*)sectorBuff;
 
 		}
 
@@ -301,7 +268,7 @@ size_t cd::IsoWriter::WriteBytesRaw(const void* data, size_t bytes) {
 
 }
 
-size_t  cd::IsoWriter::WriteBlankSectors(const size_t count)
+size_t  IsoWriter::WriteBlankSectors(const size_t count)
 {
 	const char blank[CD_SECTOR_SIZE] {};
 	
@@ -313,39 +280,411 @@ size_t  cd::IsoWriter::WriteBlankSectors(const size_t count)
 	return bytesWritten;
 }
 
-int cd::IsoWriter::CurrentSector() {
+int IsoWriter::CurrentSector() {
 
 	return currentSector;
 
 }
 
-void cd::IsoWriter::SetSubheader(unsigned char* data) {
+void IsoWriter::SetSubheader(unsigned char* data) {
 
-	memcpy(cd::IsoWriter::subHeadBuff, data, 4);
-	memcpy(cd::IsoWriter::subHeadBuff+4, data, 4);
-
-}
-
-void cd::IsoWriter::SetSubheader(unsigned int data) {
-
-	memcpy(cd::IsoWriter::subHeadBuff, &data, 4);
-	memcpy(cd::IsoWriter::subHeadBuff+4, &data, 4);
+	assert(!"Dead code");
 
 }
 
-void cd::IsoWriter::Close() {
+void IsoWriter::SetSubheader(unsigned int data) {
 
-	if (cd::IsoWriter::filePtr != nullptr) {
+	assert(!"Dead code");
 
-		if (cd::IsoWriter::currentByte > 0) {
-			cd::IsoWriter::PrepSector(cd::IsoWriter::lastSectorType);
+}
+
+void IsoWriter::Close() {
+
+	if (IsoWriter::filePtr != nullptr) {
+
+		if (IsoWriter::currentByte > 0) {
+			IsoWriter::PrepSector(IsoWriter::lastSectorType);
 			WriteSectorToDisc();
 		}
 
-		fclose(cd::IsoWriter::filePtr);
+		fclose(IsoWriter::filePtr);
 
 	}
 
-	cd::IsoWriter::filePtr = nullptr;
+	IsoWriter::filePtr = nullptr;
 
+}
+
+// ======================================================
+
+IsoWriter::SectorView::SectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm)
+	: m_view(mappedFile->GetView(static_cast<uint64_t>(offsetLBA) * CD_SECTOR_SIZE, static_cast<size_t>(sizeLBA) * CD_SECTOR_SIZE))
+	, m_endLBA(sizeLBA)
+	, m_edcEccForm(edcEccForm)
+{
+	m_currentSector = m_view.GetBuffer();
+}
+
+IsoWriter::SectorView::~SectorView()
+{
+	WaitForChecksumJobs();
+}
+
+void IsoWriter::SectorView::CalculateForm1()
+{
+	SECTOR_M2F1* sector = static_cast<SECTOR_M2F1*>(m_currentSector);
+
+	// Encode EDC data
+	m_checksumJobs.emplace_front(std::async(std::launch::async, &EDCECC::ComputeEdcBlock, &EDC_ECC_GEN,
+		sector->subHead, sizeof(sector->subHead) + sizeof(sector->data), sector->edc));
+
+	// Encode ECC data
+	m_checksumJobs.emplace_front(std::async(std::launch::async, [](SECTOR_M2F1* sector)
+		{
+			// Compute ECC P code
+			static const unsigned char zeroaddress[4] = { 0, 0, 0, 0 };
+			EDC_ECC_GEN.ComputeEccBlock(zeroaddress, sector->subHead, 86, 24, 2, 86, sector->ecc);
+			// Compute ECC Q code
+			EDC_ECC_GEN.ComputeEccBlock(zeroaddress, sector->subHead, 52, 43, 86, 88, sector->ecc+172);
+		}, sector));
+}
+
+void IsoWriter::SectorView::CalculateForm2()
+{
+	SECTOR_M2F2* sector = static_cast<SECTOR_M2F2*>(m_currentSector);
+	m_checksumJobs.emplace_front(std::async(std::launch::async, &EDCECC::ComputeEdcBlock, &EDC_ECC_GEN,
+		sector->data, sizeof(sector->data) - 4, sector->data + sizeof(sector->data) - 4));
+}
+
+void IsoWriter::SectorView::WaitForChecksumJobs()
+{
+	for (auto& job : m_checksumJobs)
+	{
+		job.get();
+	}
+	m_checksumJobs.clear();
+}
+
+// ======================================================
+
+class SectorViewM2F1 final : public IsoWriter::SectorView
+{
+private:
+	using SectorType = SECTOR_M2F1;
+
+public:
+	using IsoWriter::SectorView::SectorView;
+
+	~SectorViewM2F1() override
+	{
+		if (m_offsetInSector != 0)
+		{
+			NextSector();
+		}
+	}
+
+	void WriteFile(FILE* file) override
+	{
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+		const unsigned int lastLBA = m_endLBA - 1;
+
+		while (m_currentLBA < m_endLBA)
+		{
+			SetSubHeader(sector->subHead, m_currentLBA != lastLBA ? m_subHeader : IsoWriter::SubEOF);
+
+			const size_t bytesRead = fread(sector->data, 1, sizeof(sector->data), file);
+			// Fill the remainder of the sector with zeroes if applicable
+			std::fill(std::begin(sector->data) + bytesRead, std::end(sector->data), 0);
+		
+			if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+			{
+				CalculateForm1();
+			}
+			else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+			{
+				CalculateForm2();
+			}
+
+			m_currentLBA++;
+			m_currentSector = ++sector;
+		}
+	}
+
+	void WriteMemory(const void* memory, size_t size) override
+	{
+		const char* buf = static_cast<const char*>(memory);
+		const unsigned int lastLBA = m_endLBA - 1;
+
+		while (m_currentLBA < m_endLBA && size > 0)
+		{
+			SectorType* sector = static_cast<SectorType*>(m_currentSector);
+
+			if (m_offsetInSector == 0)
+			{
+				SetSubHeader(sector->subHead, m_currentLBA != lastLBA ? m_subHeader : IsoWriter::SubEOF);
+			}
+
+			const size_t memToCopy = std::min(GetSpaceInCurrentSector(), size);
+			std::copy_n(buf, memToCopy, sector->data + m_offsetInSector);
+			
+			size -= memToCopy;
+			buf += memToCopy;
+			m_offsetInSector += memToCopy;
+
+			if (m_offsetInSector >= sizeof(sector->data))
+			{
+				NextSector();
+			}
+		}
+	}
+
+	void WriteBlankSectors(unsigned int count) override
+	{
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+		const bool isForm2 = m_edcEccForm == IsoWriter::EdcEccForm::Form2;
+
+		while (m_currentLBA < m_endLBA && count > 0)
+		{
+			SetSubHeader(sector->subHead, isForm2 ? 0x00200000 : 0);
+
+			std::fill(std::begin(sector->data), std::end(sector->data), 0);
+			if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+			{
+				CalculateForm1();
+			}
+			else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+			{
+				CalculateForm2();
+			}
+
+			count--;
+			m_currentLBA++;
+			m_currentSector = ++sector;
+		}
+	}
+
+	size_t GetSpaceInCurrentSector() const override
+	{
+		return sizeof(SectorType::data) - m_offsetInSector;
+	}
+
+	void NextSector() override
+	{
+		// Fill the remainder of the sector with zeroes if applicable
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+		std::fill(std::begin(sector->data) + m_offsetInSector, std::end(sector->data), 0);
+		
+		if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+		{
+			CalculateForm1();
+		}
+		else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+		{
+			CalculateForm2();
+		}
+
+		m_offsetInSector = 0;
+		m_currentLBA++;
+		m_currentSector = sector + 1;
+	}
+
+	void SetSubheader(unsigned int subHead) override
+	{
+		m_subHeader = subHead;
+	}
+
+private:
+	void SetSubHeader(unsigned char* subHead, unsigned int data) const
+	{
+		memcpy(subHead, &data, sizeof(data));
+		memcpy(subHead+4, &data, sizeof(data));
+	}
+
+private:
+	unsigned int m_subHeader = IsoWriter::SubData;
+};
+
+auto IsoWriter::GetSectorViewM2F1(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const -> std::unique_ptr<SectorView>
+{
+	return std::make_unique<SectorViewM2F1>(m_mmap.get(), offsetLBA, sizeLBA, edcEccForm);
+}
+
+class SectorViewM2F2 final : public IsoWriter::SectorView
+{
+private:
+	using SectorType = SECTOR_M2F2;
+
+public:
+	using IsoWriter::SectorView::SectorView;
+
+	~SectorViewM2F2() override
+	{
+		if (m_offsetInSector != 0)
+		{
+			NextSector();
+		}
+	}
+
+	void WriteFile(FILE* file) override
+	{
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+
+		while (m_currentLBA < m_endLBA)
+		{
+			const size_t bytesRead = fread(sector->data, 1, sizeof(sector->data), file);
+			// Fill the remainder of the sector with zeroes if applicable
+			std::fill(std::begin(sector->data) + bytesRead, std::end(sector->data), 0);
+		
+			if (m_edcEccForm != IsoWriter::EdcEccForm::Autodetect)
+			{
+				if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+				{
+					CalculateForm1();
+				}
+				else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+				{
+					CalculateForm2();
+				}
+			}
+			else
+			{
+				// Check submode if sector is mode 2 form 2
+				if ( sector->data[2] & 0x20 )
+				{
+					// If so, write it as an XA sector
+					CalculateForm2();
+				}
+				else
+				{
+					// Otherwise, write it as Mode 2 Form 1
+					CalculateForm1();
+				}
+			}
+
+			m_currentLBA++;
+			m_currentSector = ++sector;
+		}
+	}
+
+	void WriteMemory(const void* memory, size_t size) override
+	{
+		const char* buf = static_cast<const char*>(memory);
+		const unsigned int lastLBA = m_endLBA - 1;
+
+		while (m_currentLBA < m_endLBA && size > 0)
+		{
+			SectorType* sector = static_cast<SectorType*>(m_currentSector);
+
+			const size_t memToCopy = std::min(GetSpaceInCurrentSector(), size);
+			std::copy_n(buf, memToCopy, sector->data + m_offsetInSector);
+			
+			size -= memToCopy;
+			buf += memToCopy;
+			m_offsetInSector += memToCopy;
+
+			if (m_offsetInSector >= sizeof(sector->data))
+			{
+				NextSector();
+			}
+		}
+	}
+
+	void WriteBlankSectors(unsigned int count) override
+	{
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+		const bool isForm2 = m_edcEccForm == IsoWriter::EdcEccForm::Form2;
+
+		while (m_currentLBA < m_endLBA && count > 0)
+		{
+			std::fill(std::begin(sector->data), std::end(sector->data), 0);
+			if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+			{
+				CalculateForm1();
+			}
+			else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+			{
+				CalculateForm2();
+			}
+
+			count--;
+			m_currentLBA++;
+			m_currentSector = ++sector;
+		}
+	}
+
+	size_t GetSpaceInCurrentSector() const override
+	{
+		return sizeof(SectorType::data) - m_offsetInSector;
+	}
+
+	void NextSector() override
+	{
+		// Fill the remainder of the sector with zeroes if applicable
+		SectorType* sector = static_cast<SectorType*>(m_currentSector);
+		std::fill(std::begin(sector->data) + m_offsetInSector, std::end(sector->data), 0);
+		
+		if (m_edcEccForm != IsoWriter::EdcEccForm::Autodetect)
+		{
+			if (m_edcEccForm == IsoWriter::EdcEccForm::Form1)
+			{
+				CalculateForm1();
+			}
+			else if (m_edcEccForm == IsoWriter::EdcEccForm::Form2)
+			{
+				CalculateForm2();
+			}
+		}
+		else
+		{
+			// Check submode if sector is mode 2 form 2
+			if ( sector->data[2] & 0x20 )
+			{
+				// If so, write it as an XA sector
+				CalculateForm2();
+			}
+			else
+			{
+				// Otherwise, write it as Mode 2 Form 1
+				CalculateForm1();
+			}
+		}
+
+		m_offsetInSector = 0;
+		m_currentLBA++;
+		m_currentSector = sector + 1;
+	}
+
+	void SetSubheader(unsigned int subHead) override
+	{
+		// Not applicable to M2F2 sectors
+	}
+};
+
+auto IsoWriter::GetSectorViewM2F2(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const -> std::unique_ptr<SectorView>
+{
+	return std::make_unique<SectorViewM2F2>(m_mmap.get(), offsetLBA, sizeLBA, edcEccForm);
+}
+
+// ======================================================
+
+auto IsoWriter::GetRawSectorView(unsigned int offsetLBA, unsigned int sizeLBA) const -> std::unique_ptr<RawSectorView>
+{
+	return std::make_unique<RawSectorView>(m_mmap.get(), offsetLBA, sizeLBA);
+}
+
+IsoWriter::RawSectorView::RawSectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA)
+	: m_view(mappedFile->GetView(static_cast<uint64_t>(offsetLBA) * CD_SECTOR_SIZE, static_cast<size_t>(sizeLBA) * CD_SECTOR_SIZE))
+	, m_endLBA(sizeLBA)
+{
+}
+
+void* IsoWriter::RawSectorView::GetRawBuffer() const
+{
+	return m_view.GetBuffer();
+}
+
+void IsoWriter::RawSectorView::WriteBlankSectors()
+{
+	char* buf = static_cast<char*>(m_view.GetBuffer());
+	std::fill_n(buf, static_cast<size_t>(m_endLBA) * CD_SECTOR_SIZE, 0);
 }

--- a/src/mkpsxiso/cdwriter.cpp
+++ b/src/mkpsxiso/cdwriter.cpp
@@ -37,11 +37,7 @@ cd::IsoWriter::IsoWriter() {
 
 cd::IsoWriter::~IsoWriter() {
 
-	if (cd::IsoWriter::filePtr != nullptr)
-		fclose(cd::IsoWriter::filePtr);
-
-	cd::IsoWriter::filePtr = nullptr;
-
+	Close();
 }
 
 void cd::IsoWriter::PrepSector(int edcEccMode) {

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -2,7 +2,6 @@
 #define _CDWRITER_H
 
 #include "cd.h"
-#include "edcecc.h"
 #include "mmappedfile.h"
 #include <filesystem>
 #include <forward_list>
@@ -11,117 +10,86 @@
 
 namespace cd {
 
-class IsoWriter {
-
-		std::unique_ptr<MMappedFile> m_mmap;
-
-		FILE*			filePtr;
-		unsigned char	subHeadBuff[12];
-		unsigned char	sectorBuff[CD_SECTOR_SIZE];
-		SECTOR_M2F1*	sectorM2F1;
-		SECTOR_M2F2*	sectorM2F2;
-
-		EDCECC			edcEccGen;
-
-		int				currentSector;
-		int				currentByte;
-		int				bytesWritten;
-		int				lastSectorType;
-
-		void			PrepSector(int edcEccMode);
-		size_t			WriteSectorToDisc();
-
-	public:
-		enum class EdcEccForm
-		{
-			None = 0,
-			Form1,
-			Form2,
-			Autodetect,
-		};
+class IsoWriter
+{
+public:
+	enum class EdcEccForm
+	{
+		None = 0,
+		Form1,
+		Form2,
+		Autodetect,
+	};
 		
-		enum {
-			SubData	= 0x00080000,
-			SubSTR	= 0x00480100,
-			SubEOL	= 0x00090000,
-			SubEOF	= 0x00890000,
-		};
-
-		class SectorView
-		{
-		public:
-			SectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm);
-			virtual ~SectorView();
-
-			virtual void WriteFile(FILE* file) = 0;
-			virtual void WriteMemory(const void* memory, size_t size) = 0;
-			virtual void WriteBlankSectors(unsigned int count) = 0;
-			virtual size_t GetSpaceInCurrentSector() const = 0;
-			virtual void NextSector() = 0;
-			virtual void SetSubheader(unsigned int subHead) = 0;
-
-			void WaitForChecksumJobs();
-
-		protected:
-			void PrepareSectorHeader() const;
-
-			void CalculateForm1();
-			void CalculateForm2();
-
-		protected:
-			void* m_currentSector = nullptr;
-			size_t m_offsetInSector = 0;
-			unsigned int m_currentLBA = 0;
-
-			const unsigned int m_endLBA = 0;
-			const EdcEccForm m_edcEccForm = EdcEccForm::None;
-
-		private:
-			std::forward_list<std::future<void>> m_checksumJobs;
-			MMappedFile::View m_view;
-		};
-
-		class RawSectorView
-		{
-		public:
-			RawSectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA);
-
-			void* GetRawBuffer() const;
-			void WriteBlankSectors();
-
-		private:
-			MMappedFile::View m_view;
-			unsigned int m_endLBA;
-		};
-
-		IsoWriter();
-		~IsoWriter();
-
-		bool	Create(const std::filesystem::path& fileName, unsigned int sizeLBA);
-		std::unique_ptr<SectorView> GetSectorViewM2F1(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const;
-		std::unique_ptr<SectorView> GetSectorViewM2F2(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const;
-		std::unique_ptr<RawSectorView> GetRawSectorView(unsigned int offsetLBA, unsigned int sizeLBA) const;
-
-		int		SeekToSector(int sector);
-
-		int		SeekToEnd();
-
-		int		CurrentSector();
-
-		void	SetSubheader(unsigned char* data);
-		void	SetSubheader(unsigned int data);
-
-		size_t	WriteBytes(void* data, size_t bytes, int edcEccEncode);
-		size_t	WriteBytesXA(void* data, size_t bytes, int edcEccEncode);
-		size_t	WriteBytesRaw(const void* data, size_t bytes);
-		size_t  WriteBlankSectors(const size_t count);
-
-		void	Close();
-
+	enum {
+		SubData	= 0x00080000,
+		SubSTR	= 0x00480100,
+		SubEOL	= 0x00090000,
+		SubEOF	= 0x00890000,
 	};
 
-	ISO_USHORT_PAIR SetPair16(unsigned short val);
-	ISO_UINT_PAIR SetPair32(unsigned int val);
+	class SectorView
+	{
+	public:
+		SectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm);
+		virtual ~SectorView();
+
+		virtual void WriteFile(FILE* file) = 0;
+		virtual void WriteMemory(const void* memory, size_t size) = 0;
+		virtual void WriteBlankSectors(unsigned int count) = 0;
+		virtual size_t GetSpaceInCurrentSector() const = 0;
+		virtual void NextSector() = 0;
+		virtual void SetSubheader(unsigned int subHead) = 0;
+
+		void WaitForChecksumJobs();
+
+	protected:
+		void PrepareSectorHeader() const;
+
+		void CalculateForm1();
+		void CalculateForm2();
+
+	protected:
+		void* m_currentSector = nullptr;
+		size_t m_offsetInSector = 0;
+		unsigned int m_currentLBA = 0;
+
+		const unsigned int m_endLBA = 0;
+		const EdcEccForm m_edcEccForm = EdcEccForm::None;
+
+	private:
+		std::forward_list<std::future<void>> m_checksumJobs;
+		MMappedFile::View m_view;
+	};
+
+	class RawSectorView
+	{
+	public:
+		RawSectorView(MMappedFile* mappedFile, unsigned int offsetLBA, unsigned int sizeLBA);
+
+		void* GetRawBuffer() const;
+		void WriteBlankSectors();
+
+	private:
+		MMappedFile::View m_view;
+		unsigned int m_endLBA;
+	};
+
+	IsoWriter() = default;
+
+	bool Create(const std::filesystem::path& fileName, unsigned int sizeLBA);
+	void Close();
+
+	std::unique_ptr<SectorView> GetSectorViewM2F1(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const;
+	std::unique_ptr<SectorView> GetSectorViewM2F2(unsigned int offsetLBA, unsigned int sizeLBA, EdcEccForm edcEccForm) const;
+	std::unique_ptr<RawSectorView> GetRawSectorView(unsigned int offsetLBA, unsigned int sizeLBA) const;
+
+private:
+	std::unique_ptr<MMappedFile> m_mmap;
+};
+
+ISO_USHORT_PAIR SetPair16(unsigned short val);
+ISO_UINT_PAIR SetPair32(unsigned int val);
 
 };
 

--- a/src/mkpsxiso/cdwriter.h
+++ b/src/mkpsxiso/cdwriter.h
@@ -62,16 +62,19 @@ class IsoWriter {
 
 			void WaitForChecksumJobs();
 
-		protected:		
+		protected:
+			void PrepareSectorHeader() const;
+
 			void CalculateForm1();
 			void CalculateForm2();
 
 		protected:
 			void* m_currentSector = nullptr;
 			size_t m_offsetInSector = 0;
-			unsigned int m_endLBA = 0;
 			unsigned int m_currentLBA = 0;
-			EdcEccForm m_edcEccForm;
+
+			const unsigned int m_endLBA = 0;
+			const EdcEccForm m_edcEccForm = EdcEccForm::None;
 
 		private:
 			std::forward_list<std::future<void>> m_checksumJobs;

--- a/src/mkpsxiso/edcecc.cpp
+++ b/src/mkpsxiso/edcecc.cpp
@@ -12,31 +12,31 @@ EDCECC::EDCECC() {
 	for(i=0; i<256; i++) {
 
 		j = (i<<1)^(i&0x80?0x11D:0);
-		EDCECC::ecc_f_lut[i] = j;
-		EDCECC::ecc_b_lut[i^j] = i;
+		ecc_f_lut[i] = j;
+		ecc_b_lut[i^j] = i;
 		edc = i;
 
 		for(j=0; j<8; j++)
 			edc=(edc>>1)^(edc&1?0xD8018001:0);
 
-		EDCECC::edc_lut[i] = edc;
+		edc_lut[i] = edc;
 
 	}
 
 }
 
-unsigned int EDCECC::ComputeEdcBlockPartial(unsigned int edc, const unsigned char *src, int len) {
+unsigned int EDCECC::ComputeEdcBlockPartial(unsigned int edc, const unsigned char *src, size_t len) const {
 
 	while(len--)
-		edc = (edc>>8)^EDCECC::edc_lut[(edc^(*src++))&0xFF];
+		edc = (edc>>8)^edc_lut[(edc^(*src++))&0xFF];
 
 	return edc;
 
 }
 
-void EDCECC::ComputeEdcBlock(const unsigned char *src, int len, unsigned char *dest) {
+void EDCECC::ComputeEdcBlock(const unsigned char *src, size_t len, unsigned char *dest) const {
 
-	unsigned int edc = EDCECC::ComputeEdcBlockPartial(0, src, len);
+	unsigned int edc = ComputeEdcBlockPartial(0, src, len);
 
 	dest[0] = (edc>>0)&0xFF;
 	dest[1] = (edc>>8)&0xFF;
@@ -45,7 +45,7 @@ void EDCECC::ComputeEdcBlock(const unsigned char *src, int len, unsigned char *d
 
 }
 
-void EDCECC::ComputeEccBlock(const unsigned char *address, const unsigned char *src, unsigned int major_count, unsigned int minor_count, unsigned int major_mult, unsigned int minor_inc, unsigned char *dest) {
+void EDCECC::ComputeEccBlock(const unsigned char *address, const unsigned char *src, unsigned int major_count, unsigned int minor_count, unsigned int major_mult, unsigned int minor_inc, unsigned char *dest) const {
 
 	unsigned int len = major_count*minor_count;
 	unsigned int major,minor;
@@ -72,11 +72,11 @@ void EDCECC::ComputeEccBlock(const unsigned char *address, const unsigned char *
 
 			ecc_a ^= temp;
 			ecc_b ^= temp;
-			ecc_a = EDCECC::ecc_f_lut[ecc_a];
+			ecc_a = ecc_f_lut[ecc_a];
 
 		}
 
-		ecc_a = EDCECC::ecc_b_lut[EDCECC::ecc_f_lut[ecc_a]^ecc_b];
+		ecc_a = ecc_b_lut[ecc_f_lut[ecc_a]^ecc_b];
 		dest[major] = ecc_a;
 		dest[major+major_count] = ecc_a^ecc_b;
 

--- a/src/mkpsxiso/edcecc.h
+++ b/src/mkpsxiso/edcecc.h
@@ -21,13 +21,13 @@ public:
 	EDCECC();
 
 	// Computes the EDC of *src and returns the result
-	unsigned int	ComputeEdcBlockPartial(unsigned int edc, const unsigned char *src, int len);
+	unsigned int	ComputeEdcBlockPartial(unsigned int edc, const unsigned char *src, size_t len) const;
 
 	// Computes the EDC of *src and stores the result to an unsigned char array *dest
-	void	ComputeEdcBlock(const unsigned char *src, int len, unsigned char *dest);
+	void	ComputeEdcBlock(const unsigned char *src, size_t len, unsigned char *dest) const;
 
 	// Computes the ECC data of *src and stores the result to an unsigned char array *dest
-	void	ComputeEccBlock(const unsigned char *address, const unsigned char *src, unsigned int major_count, unsigned int minor_count, unsigned int major_mult, unsigned int minor_inc, unsigned char *dest);
+	void	ComputeEccBlock(const unsigned char *address, const unsigned char *src, unsigned int major_count, unsigned int minor_count, unsigned int major_mult, unsigned int minor_inc, unsigned char *dest) const;
 
 };
 

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -74,7 +74,7 @@ int iso::DirTreeClass::GetAudioSize(const std::filesystem::path& audioFile)
         return 0;
 	}
 
-	return GetSizeInSectors(expectedPCMFrames * 2 * (sizeof(int16_t)), 2352)*2352;
+	return GetSizeInSectors(expectedPCMFrames * 2 * (sizeof(int16_t)), CD_SECTOR_SIZE)*CD_SECTOR_SIZE;
 }
 
 iso::DirTreeClass::DirTreeClass(EntryList& entries, DirTreeClass* parent)
@@ -653,7 +653,7 @@ int iso::DirTreeClass::WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENT
 	return 1;
 }
 
-int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
+bool iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer) const
 {
 	for ( const DIRENTRY& entry : entries )
 	{
@@ -847,7 +847,7 @@ int iso::DirTreeClass::WriteFiles(cd::IsoWriter* writer)
 		}
 	}
 
-	return 1;
+	return true;
 }
 
 void iso::DirTreeClass::OutputHeaderListing(FILE* fp, int level) const

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -185,7 +185,7 @@ namespace iso
 		 *
 		 *	*writer	- Pointer to a cd::IsoWriter class that is ready for writing.
 		 */
-		int	WriteFiles(cd::IsoWriter* writer);
+		bool WriteFiles(cd::IsoWriter* writer) const;
 
 		/**	Writes the file system of the directory records to a CD image. Execute this after the source files
 		 *	have been written to the CD image.

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -107,7 +107,7 @@ namespace iso
 		DirTreeClass* parent = nullptr; // Non-owning
 		
 		/// Internal function for generating and writing directory records
-		int	WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir) const;
+		bool WriteDirEntries(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir) const;
 
 		/// Internal function for recursive path table generation
 		std::unique_ptr<PathTableClass> GenPathTableSub(unsigned short& index, unsigned short parentIndex) const;
@@ -195,7 +195,7 @@ namespace iso
 		 *  parentLBA	   - Parent directory LBA
 		 *  currentDirDate - Timestamp to use for . and .. directories.
 		 */
-		int	WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir);
+		bool WriteDirectoryRecords(cd::IsoWriter* writer, const DIRENTRY& dir, const DIRENTRY& parentDir);
 
 		void SortDirectoryEntries();
 

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -16,6 +16,18 @@ enum class EntryType
 	EntryDummy
 };
 
+struct cdtrack
+{
+	cdtrack(unsigned int lba, unsigned int size, std::string source = std::string())
+		: lba(lba), size(size), source(std::move(source))
+	{
+	}
+
+	unsigned int lba;
+	unsigned int size;
+	std::string source;
+};
+
 // Helper functions for datestamp manipulation
 cd::ISO_DATESTAMP GetDateFromString(const char* str, bool* success = nullptr);
 

--- a/src/shared/mmappedfile.cpp
+++ b/src/shared/mmappedfile.cpp
@@ -1,0 +1,90 @@
+#include "mmappedfile.h"
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+MMappedFile::MMappedFile()
+	: m_handle(nullptr)
+{
+}
+
+MMappedFile::~MMappedFile()
+{
+#ifdef _WIN32
+	if (m_handle != nullptr)
+	{
+		CloseHandle(reinterpret_cast<HANDLE>(m_handle));
+	}
+#else
+	// TODO: Do
+#endif
+}
+
+bool MMappedFile::Create(const std::filesystem::path& filePath, uint64_t size)
+{
+	bool result = false;
+
+#ifdef _WIN32
+	HANDLE file = CreateFileW(filePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_DELETE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+	if (file != INVALID_HANDLE_VALUE)
+	{
+		ULARGE_INTEGER ulSize;
+		ulSize.QuadPart = size;
+
+		HANDLE fileMapping = CreateFileMappingW(file, nullptr, PAGE_READWRITE, ulSize.HighPart, ulSize.LowPart, nullptr);
+		if (fileMapping != nullptr)
+		{
+			m_handle = fileMapping;
+			result = true;
+		}
+
+		CloseHandle(file);
+	}
+#else
+	// TODO: Do
+#endif
+	return result;
+}
+
+MMappedFile::View MMappedFile::GetView(uint64_t offset, size_t size) const
+{
+	return View(m_handle, offset, size);
+}
+
+MMappedFile::View::View(void* handle, uint64_t offset, size_t size)
+{
+#ifdef _WIN32
+	SYSTEM_INFO SysInfo;
+	GetSystemInfo(&SysInfo);
+	const DWORD allocGranularity = SysInfo.dwAllocationGranularity;
+
+	const uint64_t mapStartOffset = (offset / allocGranularity) * allocGranularity;
+	const uint64_t viewDelta = offset - mapStartOffset;
+	size += viewDelta;
+
+	ULARGE_INTEGER ulOffset;
+	ulOffset.QuadPart = mapStartOffset;
+	m_mapping = MapViewOfFile(reinterpret_cast<HANDLE>(handle), FILE_MAP_ALL_ACCESS, ulOffset.HighPart, ulOffset.LowPart, size);
+	if (m_mapping != nullptr)
+	{
+		m_data = static_cast<char*>(m_mapping) + viewDelta;
+	}
+
+#else
+	// TODO: Do
+#endif
+}
+
+MMappedFile::View::~View()
+{
+#ifdef _WIN32
+	if (m_mapping != nullptr)
+	{
+		UnmapViewOfFile(m_mapping);
+	}
+#else
+
+#endif
+}

--- a/src/shared/mmappedfile.h
+++ b/src/shared/mmappedfile.h
@@ -19,6 +19,7 @@ public:
 	private:
 		void* m_mapping = nullptr; // Aligned down to allocation granularity
 		void* m_data = nullptr;
+		size_t m_size = 0; // Real size, with adjustments to granularity
 	};
 
 	MMappedFile();
@@ -28,5 +29,5 @@ public:
 	View GetView(uint64_t offset, size_t size) const;
 
 private:
-	void* m_handle; // Opaque, platform-specific
+	void* m_handle = nullptr; // Opaque, platform-specific
 };

--- a/src/shared/mmappedfile.h
+++ b/src/shared/mmappedfile.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Cross-platform memory mapped file wrapper
+
+#include <cstdint>
+#include <filesystem>
+
+class MMappedFile
+{
+public:
+	class View
+	{
+	public:
+		View(void* handle, uint64_t offset, size_t size);
+		~View();
+
+		void* GetBuffer() const { return m_data; }
+
+	private:
+		void* m_mapping = nullptr; // Aligned down to allocation granularity
+		void* m_data = nullptr;
+	};
+
+	MMappedFile();
+	~MMappedFile();
+
+	bool Create(const std::filesystem::path& filePath, uint64_t size);
+	View GetView(uint64_t offset, size_t size) const;
+
+private:
+	void* m_handle; // Opaque, platform-specific
+};


### PR DESCRIPTION
This PR completely refactors `IsoWriter` to use memory mapped files to create the image. This results in:
* Cleaner code - files can be read in chunks directly to a preallocated memory address that is backed by a file.
* Asynchronous ECC/EDC computation - now checksums are calculated for sectors "on the side" and they are finalized only when closing the view.

In order not to explode RAM usage too much, views are mapped on per-file basis. This means that the max RAM usage of this new solution is roughly equivalent to the size of sectors occupied by the biggest file.

**NOTE:** I have not tested it on Linux! It would be good to know if it even works there.