### PR TITLE
mkpsxiso,dumpsxiso fix multiple path issues

### DIFF
--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -603,7 +603,7 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
 		{
 			newelement = dirElement->InsertNewChildElement("dir");
 			newelement->SetAttribute(xml::attrib::ENTRY_NAME, entry.identifier.c_str());
-			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_u8string().c_str());
+			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.lexically_normal().generic_u8string().c_str());
 		}
 		else
 		{
@@ -623,7 +623,7 @@ tinyxml2::XMLElement* WriteXMLEntry(const cd::IsoDirEntries::Entry& entry, tinyx
         newelement->SetAttribute(xml::attrib::ENTRY_NAME, std::string(CleanIdentifier(entry.identifier)).c_str());
 		if(entryType != EntryType::EntryDA)
 		{
-			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.generic_u8string().c_str());
+			newelement->SetAttribute(xml::attrib::ENTRY_SOURCE, outputPath.lexically_normal().generic_u8string().c_str());
 		}
 		else
 		{
@@ -846,16 +846,18 @@ void ParseISO(cd::IsoReader& reader) {
 				}
 			}
 
+			const std::filesystem::path xmlPath = param::xmlFile.parent_path().lexically_normal();
+
 			{
 				tinyxml2::XMLElement *newElement = trackElement->InsertNewChildElement(xml::elem::LICENSE);
 				newElement->SetAttribute(xml::attrib::LICENSE_FILE,
-					(param::outPath / "license_data.dat").lexically_proximate(param::xmlFile.parent_path()).generic_u8string().c_str());
+					(param::outPath / "license_data.dat").lexically_proximate(xmlPath).generic_u8string().c_str());
 			}
 
 			// Create <default_attributes> now so it lands before the directory tree
 			tinyxml2::XMLElement* defaultAttributesElement = trackElement->InsertNewChildElement(xml::elem::DEFAULT_ATTRIBUTES);
 
-			const std::filesystem::path sourcePath = param::outPath.lexically_proximate(param::xmlFile.parent_path());
+			const std::filesystem::path sourcePath = param::outPath.lexically_proximate(xmlPath);
 
 			// process DA "files" to tracks and add to the dirs so the XML looks nicer
 			std::vector<std::list<cd::IsoDirEntries::Entry>::const_iterator> dafiles;
@@ -869,7 +871,7 @@ void ParseISO(cd::IsoReader& reader) {
 			std::vector<cdtrack> tracks;
 			for(const auto& dafile : dafiles)
 			{
-				auto tracksource = GetRealDAFilePath(sourcePath / dafile->virtualPath / CleanIdentifier(dafile->identifier));
+				auto tracksource = GetRealDAFilePath(sourcePath / dafile->virtualPath / CleanIdentifier(dafile->identifier)).lexically_normal();
 
 				// add to make track element later
 				tracks.emplace_back(

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -536,7 +536,7 @@ int Main(int argc, char* argv[])
 				}
 
 				// Write track information to the CUE sheet
-				if ( const char* track_source = trackElement->Attribute(xml::attrib::TRACK_SOURCE); track_source == nullptr )
+				if ( const char* trackRelativeSource = trackElement->Attribute(xml::attrib::TRACK_SOURCE); trackRelativeSource == nullptr )
 				{
 					if ( !global::QuietMode )
 					{
@@ -550,6 +550,7 @@ int Main(int argc, char* argv[])
 				}
 				else
 				{
+					std::filesystem::path trackSource = (global::XMLscript.parent_path() / trackRelativeSource);
 					fprintf( cuefp.get(), "  TRACK %02d AUDIO\n", global::trackNum );
 
 					// pregap
@@ -597,8 +598,8 @@ int Main(int argc, char* argv[])
 						}
 					}
 
-					const unsigned int audioSize = iso::DirTreeClass::GetAudioSize(track_source);
-					audioTracks.emplace_back(totalLenLBA, audioSize, track_source);
+					const unsigned int audioSize = iso::DirTreeClass::GetAudioSize(trackSource);
+					audioTracks.emplace_back(totalLenLBA, audioSize, trackSource.generic_u8string());
 
 					totalLenLBA += audioSize/CD_SECTOR_SIZE;
 				}


### PR DESCRIPTION
 mkpsxiso: fix track source not being relative to xml path.

dumpsxiso: generate more concise paths in xml. Fixes https://github.com/CookiePLMonster/mkpsxiso/issues/17