### PR TITLE
mkpsxiso: Update log statements to reflect progress

### DIFF
--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -968,7 +968,7 @@ int Main(int argc, char *argv[])
     printf( "DUMPSXISO " VERSION " - PlayStation ISO dumping tool\n"
 			"2017 Meido-Tek Productions (Lameguy64)\n"
 			"2020 Phoenix (SadNES cITy)\n"
-			"2021 Silent, Chromaryu, and G4Vi\n\n" );
+			"2021-2022 Silent, Chromaryu, G4Vi, and spicyjpeg\n\n" );
 
 	if (argc == 1)
 	{

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -458,7 +458,10 @@ int Main(int argc, char* argv[])
 		const tinyxml2::XMLElement* dataTrack = nullptr;
 
 		// Parse tracks
-		printf("Scanning tracks...\n\n");
+		if ( !global::QuietMode )
+		{
+			printf("Scanning tracks...\n\n");
+		}
 		for ( const tinyxml2::XMLElement* trackElement = projectElement->FirstChildElement(xml::elem::TRACK);
 			trackElement != nullptr; trackElement = trackElement->NextSiblingElement(xml::elem::TRACK) )
 		{
@@ -552,10 +555,6 @@ int Main(int argc, char* argv[])
 				else
 				{
 					std::filesystem::path trackSource = (global::XMLscript.parent_path() / trackRelativeSource);
-					if ( !global::QuietMode )
-					{
-						//printf("    source %s\n", trackSource.generic_u8string().c_str());
-					}
 					fprintf( cuefp.get(), "  TRACK %02d AUDIO\n", global::trackNum );
 
 					// pregap

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -95,7 +95,7 @@ int Main(int argc, char* argv[])
 	static constexpr const char* VERSION_TEXT =
 		"MKPSXISO " VERSION " - PlayStation ISO Image Maker\n"
 		"2017-2018 Meido-Tek Productions (Lameguy64)\n"
-		"2021 Silent, Chromaryu, and G4Vi\n\n";
+		"2021-2022 Silent, Chromaryu, G4Vi, and spicyjpeg\n\n";
 
 	bool OutputOverride = false;
 


### PR DESCRIPTION
The first phase is now "Scanning tracks". Audio tracks in the scanning phase now print out their associated DA file names. After the scanning phase and lba message the "Writing ISO" phase begins:
- Writing files
- Writing CDDA tracks
- Writing license data
- Writing directories

Credits were updated with 2022 and to include @spicyjpeg

`dumpsxiso` log messages appeared to be okay.


