### PR TITLE
Switch to upstream libflac

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mackron/miniaudio
 [submodule "flac"]
 	path = flac
-	url = https://github.com/CookiePLMonster/flac
+	url = https://github.com/xiph/flac
 [submodule "ghc"]
 	path = ghc
 	url = https://github.com/gulrak/filesystem


### PR DESCRIPTION
Verified output of dumpsxiso -> mkpsxiso is the same when dumpsxiso encodes flac.

However, ktmf01 has still been making a ton of changes, so it might make sense to update libflac again before the next release or merge.