### PR TITLE
Fix building images with big directories (more than 36 files)

### DIFF
--- a/src/dumpsxiso/main.cpp
+++ b/src/dumpsxiso/main.cpp
@@ -838,6 +838,7 @@ void ParseISO(cd::IsoReader& reader) {
 				setAttributeIfNotEmpty(xml::attrib::VOLUME_SET, CleanDescElement(descriptor.volumeSetIdentifier));
 				setAttributeIfNotEmpty(xml::attrib::PUBLISHER, CleanDescElement(descriptor.publisherIdentifier));
 				setAttributeIfNotEmpty(xml::attrib::DATA_PREPARER, CleanDescElement(descriptor.dataPreparerIdentifier));
+				setAttributeIfNotEmpty(xml::attrib::COPYRIGHT, CleanDescElement(descriptor.copyrightFileIdentifier));
 				newElement->SetAttribute(xml::attrib::CREATION_DATE, LongDateToString(descriptor.volumeCreateDate).c_str());
 				if (auto ZERO_DATE = GetUnspecifiedLongDate(); memcmp(&descriptor.volumeModifyDate, &ZERO_DATE, sizeof(descriptor.volumeModifyDate)) != 0)
 				{

--- a/src/mkpsxiso/global.h
+++ b/src/mkpsxiso/global.h
@@ -8,7 +8,6 @@ namespace global {
 	extern time_t	BuildTime;
 	extern int		QuietMode;
 	extern int		noXA;
-	extern int		NoLimit;
 	extern int		trackNum;
 };
 

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -378,7 +378,7 @@ int iso::DirTreeClass::CalculateTreeLBA(int lba)
 	return lba;
 }
 
-int iso::DirTreeClass::CalculateDirEntryLen(bool* passedSector) const
+int iso::DirTreeClass::CalculateDirEntryLen() const
 {
 	int dirEntryLen = 68;
 
@@ -412,11 +412,6 @@ int iso::DirTreeClass::CalculateDirEntryLen(bool* passedSector) const
 		}
 
 		dirEntryLen += dataLen;
-	}
-
-	if (dirEntryLen > 2048 && passedSector != nullptr)
-	{
-		*passedSector = true;
 	}
 
 	return 2048 * GetSizeInSectors(dirEntryLen);

--- a/src/mkpsxiso/iso.cpp
+++ b/src/mkpsxiso/iso.cpp
@@ -340,19 +340,6 @@ void iso::DirTreeClass::PrintRecordPath()
 
 int iso::DirTreeClass::CalculateTreeLBA(int lba)
 {
-	bool passedSector = false;
-	lba += GetSizeInSectors(CalculateDirEntryLen(&passedSector));
-
-	if ( ( global::NoLimit == false) && passedSector )
-	{
-		if (!global::QuietMode)
-			printf("      ");
-
-		printf("WARNING: Directory record ");
-		PrintRecordPath();
-		printf(" exceeds 2048 bytes.\n");
-	}
-
 	bool firstDAWritten = false;
 	for ( DIRENTRY& entry : entries )
 	{

--- a/src/mkpsxiso/iso.h
+++ b/src/mkpsxiso/iso.h
@@ -99,10 +99,8 @@ namespace iso
 		/** Calculates the length of the directory record to be produced by this class in bytes.
 		 *
 		 *  Returns: Length of directory record in bytes.
-		 * 
-		 * * *passedSector - Flag to indicate if the directory record has exceeded a sector
 		 */
-		int	CalculateDirEntryLen(bool* passedSector = nullptr) const;
+		int	CalculateDirEntryLen() const;
 
 		/** Calculates the LBA of all file and directory entries in the directory record and returns the next LBA
 		 *	address.

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -1072,7 +1072,8 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 	// Calculate directory tree LBAs and retrieve size of image
 	int pathTableLen = dirTree->CalculatePathTableLen(root);
 
-	const int rootLBA = 17+(GetSizeInSectors(pathTableLen)*4);
+	// 16 license sectors + 2 header sectors
+	const int rootLBA = 18+(GetSizeInSectors(pathTableLen)*4);
 	totalLen = dirTree->CalculateTreeLBA(rootLBA);
 
 	if ( !global::QuietMode )

--- a/src/mkpsxiso/main.cpp
+++ b/src/mkpsxiso/main.cpp
@@ -29,7 +29,6 @@ namespace global
 	int			QuietMode	= false;
 	int			Overwrite	= false;
 
-	int			NoLimit		= false;
 	int			trackNum	= 1;
 	int			noXA		= false;
 
@@ -76,7 +75,7 @@ int Main(int argc, char* argv[])
 {
 	static constexpr const char* HELP_TEXT =
 		"mkpsxiso [-h|--help] [-y] [-q|--quiet] [-o|--output <file>] [-lba <file>] [-lbahead <file>]\n"
-		"  [-rebuildxml <file>] [-nolimit] [-noisogen] <xml>\n\n"
+		"  [-rebuildxml <file>] [-noisogen] <xml>\n\n"
 		"  -y        - Always overwrite ISO image files.\n"
 		"  -q|--quiet - Quiet mode (prints nothing but warnings and errors).\n"
 		"  -o|--output - Specifies output file name (overrides XML but not cue_sheet).\n"
@@ -84,7 +83,6 @@ int Main(int argc, char* argv[])
 		"Special Options:\n\n"
 		"  -lba      - Outputs a log of all files packed with LBA information.\n"
 		"  -lbahead  - Outputs a C header of all the file's LBA addresses.\n"
-		"  -nolimit  - Remove warning when a directory record exceeds a sector.\n"
 		"  -noisogen - Do not generate ISO but calculates file LBAs only\n"
 		"              (To be used with -lba or -lbahead without generating ISO).\n"
 		"  -noxa     - Do not generate CD-XA file attributes\n"
@@ -114,11 +112,6 @@ int Main(int argc, char* argv[])
 			if (auto lbaHead = ParsePathArgument(args, "lbahead"); lbaHead.has_value())
 			{
 				global::LBAheaderFile = *lbaHead;
-				continue;
-			}
-			if (ParseArgument(args, "nolimit"))
-			{
-				global::NoLimit = true;
 				continue;
 			}
 			if (ParseArgument(args, "noisogen"))
@@ -1082,16 +1075,6 @@ int ParseISOfileSystem(const tinyxml2::XMLElement* trackElement, const fs::path&
 		printf( "      Directories: %d\n", dirTree->GetDirCountTotal() );
 		printf( "      Total file system size: %d bytes (%d sectors)\n\n",
 			CD_SECTOR_SIZE*totalLen, totalLen);
-	}
-
-	if ( (global::NoLimit == false) &&
-		(pathTableLen > 2048) )
-	{
-		if ( !global::QuietMode )
-		{
-			printf( "      " );
-		}
-		printf( "WARNING: Path table exceeds 2048 bytes.\n" );
 	}
 
 	return true;


### PR DESCRIPTION
LBAs of big directories spanning more than one sector were miscounted. This PR fixes it while also simplifying code.

Fixes building **Need for Speed: High Stakes**:
http://redump.org/disc/114/